### PR TITLE
Prevent race conditions during updating models

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ class Comment < ActiveRecord::Base
   belongs_to :article
 
   plus_plus :user, :comments_count
-  plus_plus :user, :score, value: 5, unless: proc { fake_comment }
+  plus_plus :user, :score, value: 5, update_method: :update_attributes, unless: proc { fake_comment }
   plus_plus :article, :comments_count, unless: proc { fake_comment }
   plus_plus_on_change :article, :comments_count, changed: :fake_comment, plus: false, minus: true
-  plus_plus_on_change :user, :score, changed: :fake_comment, plus: proc { !fake_comment }, minus: proc { fake_comment }, value: 5
+  plus_plus_on_change :user, :score, changed: :fake_comment, plus: proc { !fake_comment }, minus: proc { fake_comment }, value: 5, update_method: :update_attributes
 end
 ```
 
@@ -94,12 +94,14 @@ Let's bring it all home now:
 - value: Defaults to 1. Can be set to a static integer value or a proc
 - if: Only update if this condition is satisifed
 - unless: Update unless this condition is satisifed
+- update_method: Defaults to update_columns to avoid triggering callbacks and to be as fast as possible. Set to update_attributes or your own custom method if you prefer callbacks or something different.
 
 **plus_plus_on_change**
 - changed: (Required) The column to monitor for a change
 - plus: (Required) The condition that must be satisfied in order to increment the column. Can be a proc (that evaluates to true/false) or a static value that will be checked for equality against the changed column
 - minus: (Required) The condition that must be satisfied in order to decrement the column. Can be a proc (that evaluates to true/false) or a static value that will be checked for equality against the changed column
 - value: Defaults to 1. Can be set to a static integer value or a proc
+- update_method: Defaults to update_columns to avoid triggering callbacks and to be as fast as possible. Set to update_attributes or your own custom method if you prefer callbacks or something different.
 
 The MIT License (MIT)
 ---------------------

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ class Comment < ActiveRecord::Base
   belongs_to :article
 
   plus_plus :user, :comments_count
-  plus_plus :user, :score, value: 5, update_method: :update_attributes, unless: proc { fake_comment }
+  plus_plus :user, :score, value: 5, unless: proc { fake_comment }
   plus_plus :article, :comments_count, unless: proc { fake_comment }
   plus_plus_on_change :article, :comments_count, changed: :fake_comment, plus: false, minus: true
-  plus_plus_on_change :user, :score, changed: :fake_comment, plus: proc { !fake_comment }, minus: proc { fake_comment }, value: 5, update_method: :update_attributes
+  plus_plus_on_change :user, :score, changed: :fake_comment, plus: proc { !fake_comment }, minus: proc { fake_comment }, value: 5
 end
 ```
 
@@ -94,14 +94,12 @@ Let's bring it all home now:
 - value: Defaults to 1. Can be set to a static integer value or a proc
 - if: Only update if this condition is satisifed
 - unless: Update unless this condition is satisifed
-- update_method: Defaults to update_columns to avoid triggering callbacks and to be as fast as possible. Set to update_attributes or your own custom method if you prefer callbacks or something different.
 
 **plus_plus_on_change**
 - changed: (Required) The column to monitor for a change
 - plus: (Required) The condition that must be satisfied in order to increment the column. Can be a proc (that evaluates to true/false) or a static value that will be checked for equality against the changed column
 - minus: (Required) The condition that must be satisfied in order to decrement the column. Can be a proc (that evaluates to true/false) or a static value that will be checked for equality against the changed column
 - value: Defaults to 1. Can be set to a static integer value or a proc
-- update_method: Defaults to update_columns to avoid triggering callbacks and to be as fast as possible. Set to update_attributes or your own custom method if you prefer callbacks or something different.
 
 The MIT License (MIT)
 ---------------------

--- a/lib/plus_plus/base.rb
+++ b/lib/plus_plus/base.rb
@@ -1,7 +1,25 @@
 module PlusPlus
   module Base
+    def plus_plus_warning_about_removal_update_method_from_options(options)
+      return unless options[:update_method]
+
+      puts <<-EOQ
+      WARNING:
+        `:update_method` option was removed from both `plus_plus` and
+        `plus_plus_on_change` methods and has no longer effect. Please
+        delete the option from your code as well.
+
+        See more details here: https://github.com/Pathgather/plus-plus/pull/1.
+
+        If you depend on the previous behaviour, please update your Gemfile:
+        `gem 'plus-plus', github: 'pathgather/plus-plus', ref: '6fd9910'`.\n
+      EOQ
+    end
+
     def plus_plus(*args)
       options = args.extract_options!
+      plus_plus_warning_about_removal_update_method_from_options(options)
+
       association, column = args
 
       after_create do
@@ -15,11 +33,11 @@ module PlusPlus
 
     def plus_plus_on_change(*args)
       options = args.extract_options!
+      plus_plus_warning_about_removal_update_method_from_options(options)
+
       association, column = args
 
       after_update do
-        warning_about_removal_update_method_from_options(options)
-
         raise 'No :changed option specified' if options[:changed].nil?
         raise 'No :plus option specified' if options[:plus].nil?
         raise 'No :minus option specified' if options[:minus].nil?
@@ -80,25 +98,7 @@ module PlusPlus
   end
 
   module Model
-    def warning_about_removal_update_method_from_options(options)
-      return unless options[:update_method]
-
-      puts <<-EOQ
-      WARNING:
-        `:update_method` option was removed from both `plus_plus` and
-        `plus_plus_on_change` methods and has no longer effect. Please
-        delete the option from your code as well.
-
-        See more details here: https://github.com/Pathgather/plus-plus/pull/1.
-
-        If you depend on the previous behaviour, please update your Gemfile:
-        `gem 'plus-plus', github: 'pathgather/plus-plus', ref: '6fd9910'`
-      EOQ
-    end
-
     def plus_plus_on_create_or_destroy(association, column, options)
-      warning_about_removal_update_method_from_options(options)
-
       return if options.key?(:if) && !instance_exec(&options[:if])
       return if options.key?(:unless) && instance_exec(&options[:unless])
 

--- a/lib/plus_plus/base.rb
+++ b/lib/plus_plus/base.rb
@@ -78,10 +78,12 @@ module PlusPlus
 
   module Model
     def plus_plus_update(options, association_model, column_name, offset)
-      update_method = options.fetch(:update_method, :update_columns)
-      values = { column_name => association_model.send(column_name) + offset }
-
-      association_model.send(update_method, values)
+      association_model.with_lock do
+        association_model.send(
+          options.fetch(:update_method, :update_columns),
+          column_name => association_model.send(column_name) + offset
+        )
+      end
     end
 
     def plus_plus_on_create_or_destroy(association, column, options)

--- a/lib/plus_plus/base.rb
+++ b/lib/plus_plus/base.rb
@@ -42,9 +42,6 @@ module PlusPlus
         raise 'No :plus option specified' if options[:plus].nil?
         raise 'No :minus option specified' if options[:minus].nil?
 
-        association_model = send(association)
-        raise "No association #{association}" unless association_model
-
         return unless changes.include?(options[:changed])
 
         # Create a 'snapshot' of what the model did look like
@@ -89,7 +86,12 @@ module PlusPlus
                    -value
                  end
 
-        plus_plus_update(association_model, column, offset) if offset
+        if offset
+          association_model = send(association)
+          raise "No association #{association}" unless association_model
+
+          plus_plus_update(association_model, column, offset)
+        end
       end
     end
   end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -18,16 +18,6 @@ describe PlusPlus do
       it "decreases the column by 1 on destroy" do
         expect { user_with_comment.comments[0].destroy }.to change{user_with_comment.comments_count}.from(1).to(0)
       end
-
-      it "updates the association with update_columns by default on create" do
-        user.should_receive(:update_columns).with({comments_count: 1})
-        FactoryGirl.create :comment, user: user
-      end
-
-      it "updates the association with update_columns by default on destroy" do
-        user_with_comment.should_receive(:update_columns).with({comments_count: 0})
-        user_with_comment.comments[0].destroy
-      end
     end
 
     context "with a specified value" do
@@ -49,18 +39,6 @@ describe PlusPlus do
         expect {
           user_with_published_article.articles[0].destroy
         }.to change{user_with_published_article.score}.from(user_with_published_article.articles[0].content.length).to(0)
-      end
-    end
-
-    context "with a different update method" do
-      it "increases the column with that update method on create" do
-        user.should_receive(:update_attributes).with({score: 5})
-        FactoryGirl.create :comment, user: user
-      end
-
-      it "decreases the column with that update method on destroy" do
-        user_with_comment.should_receive(:update_attributes).with({score: 0})
-        user_with_comment.comments[0].destroy
       end
     end
 
@@ -156,17 +134,6 @@ describe PlusPlus do
             user_with_comment.reload
             user_with_comment.score.should == 0
           end
-        end
-      end
-    end
-
-    context "with a different update method" do
-      context "when the :changed column is changed" do
-        it "updates the column with that update method" do
-          subcomment = FactoryGirl.create :subcomment, user: user
-          user.reload
-          user.should_receive(:update_attributes).with({score: user.score + 5})
-          subcomment.update_attributes subcomment: false
         end
       end
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -9,95 +9,108 @@ describe PlusPlus do
   let(:user_with_published_article) { FactoryGirl.create(:user_with_published_article) }
   let(:user_with_unpublished_article) { FactoryGirl.create(:user_with_unpublished_article) }
 
-  describe "plus_plus" do
-    context "with the minimal configuration" do
-      it "increases the column by 1 on create" do
-        expect { FactoryGirl.create :comment, user: user }.to change{user.comments_count}.from(0).to(1)
+  describe 'plus_plus' do
+    context 'with the minimal configuration' do
+      it 'increases the column by 1 on create' do
+        expect { FactoryGirl.create :comment, user: user }
+          .to change { user.reload.comments_count }.from(0).to(1)
       end
 
-      it "decreases the column by 1 on destroy" do
-        expect { user_with_comment.comments[0].destroy }.to change{user_with_comment.comments_count}.from(1).to(0)
-      end
-    end
-
-    context "with a specified value" do
-      it "increases the column by that value on create" do
-        expect { FactoryGirl.create :comment, user: user }.to change{user.score}.from(0).to(5)
-      end
-
-      it "decreases the column by that value on destroy" do
-        expect { user_with_comment.comments[0].destroy }.to change{user_with_comment.score}.from(5).to(0)
+      it 'decreases the column by 1 on destroy' do
+        expect { user_with_comment.comments[0].destroy }
+          .to change { user_with_comment.reload.comments_count }.from(1).to(0)
       end
     end
 
-    context "with a dynamic value" do
-      it "increases the column by that value on create" do
-        expect { FactoryGirl.create :article, user: user, content: 'Test' }.to change{user.score}.from(0).to(4)
+    context 'with a specified value' do
+      it 'increases the column by that value on create' do
+        expect { FactoryGirl.create :comment, user: user }
+          .to change { user.reload.score }.from(0).to(5)
       end
 
-      it "decreases the column by that value on destroy" do
-        expect {
-          user_with_published_article.articles[0].destroy
-        }.to change{user_with_published_article.score}.from(user_with_published_article.articles[0].content.length).to(0)
-      end
-    end
-
-    context "with an if condition" do
-      context "when statisfied" do
-        it "increases the column by 1 on create" do
-          expect { FactoryGirl.create :published_article, user: user }.to change{user.articles_count}.from(0).to(1)
-        end
-
-        it "decreases the column by 1 on destroy" do
-          expect { user_with_published_article.articles[0].destroy }.to change{user_with_published_article.articles_count}.from(1).to(0)
-        end
-      end
-
-      context "when not statisfied" do
-        it "does not increase the column on create" do
-          expect { FactoryGirl.create :article, user: user }.to_not change{user.articles_count}
-        end
-
-        it "does not decrease the column on destroy" do
-          expect { user_with_unpublished_article.articles[0].destroy }.to_not change{user_with_unpublished_article.articles_count}
-        end
+      it 'decreases the column by that value on destroy' do
+        expect { user_with_comment.comments[0].destroy }
+          .to change { user_with_comment.reload.score }.from(5).to(0)
       end
     end
 
-    context "with an unless condition" do
-      context "when statisfied" do
-        it "does not increase the column on create" do
-          expect { FactoryGirl.create :subcomment, article: article }.to_not change{article.comments_count}
+    context 'with a dynamic value' do
+      it 'increases the column by that value on create' do
+        expect { FactoryGirl.create :article, user: user, content: 'Test' }
+          .to change { user.reload.score }.from(0).to(4)
+      end
+
+      it 'decreases the column by that value on destroy' do
+        article = user_with_published_article.articles[0]
+        expect { article.destroy }
+          .to change { user_with_published_article.reload.score }
+          .from(article.content.length).to(0)
+      end
+    end
+
+    context 'with an if condition' do
+      context 'when statisfied' do
+        it 'increases the column by 1 on create' do
+          expect { FactoryGirl.create :published_article, user: user }
+            .to change { user.reload.articles_count }.from(0).to(1)
         end
 
-        it "does not decrease the column on destroy" do
-          expect { article_with_subcomment.comments[0].destroy }.to_not change{article_with_subcomment.comments_count}
+        it 'decreases the column by 1 on destroy' do
+          article = user_with_published_article.articles[0]
+          expect { article.destroy }
+            .to change { user_with_published_article.reload.articles_count }
+            .from(1).to(0)
         end
       end
 
-      context "when not statisfied" do
-        it "increases the column by 1 on create" do
-          expect { FactoryGirl.create :comment, article: article }.to change{article.comments_count}.from(0).to(1)
+      context 'when not statisfied' do
+        it 'does not increase the column on create' do
+          expect { FactoryGirl.create :article, user: user }.to_not change { user.articles_count }
         end
 
-        it "decreases the column by 1 on destroy" do
-          expect { article_with_comment.comments[0].destroy }.to change{article_with_comment.comments_count}.from(1).to(0)
+        it 'does not decrease the column on destroy' do
+          expect { user_with_unpublished_article.articles[0].destroy }.to_not change { user_with_unpublished_article.articles_count }
+        end
+      end
+    end
+
+    context 'with an unless condition' do
+      context 'when statisfied' do
+        it 'does not increase the column on create' do
+          expect { FactoryGirl.create :subcomment, article: article }.to_not change { article.comments_count }
+        end
+
+        it 'does not decrease the column on destroy' do
+          expect { article_with_subcomment.comments[0].destroy }.to_not change { article_with_subcomment.comments_count }
+        end
+      end
+
+      context 'when not statisfied' do
+        it 'increases the column by 1 on create' do
+          expect { FactoryGirl.create :comment, article: article }
+            .to change { article.reload.comments_count }.from(0).to(1)
+        end
+
+        it 'decreases the column by 1 on destroy' do
+          comment = article_with_comment.comments[0]
+          expect { comment.destroy }
+            .to change { article_with_comment.reload.comments_count }.from(1).to(0)
         end
       end
     end
   end
 
-  describe "plus_plus_on_change" do
-    context "with the minimal configuration" do
-      context "when the :changed column is changed" do
-        it "updates the association with update_columns by default on create" do
+  describe 'plus_plus_on_change' do
+    context 'with the minimal configuration' do
+      context 'when the :changed column is changed' do
+        it 'updates the association with update_columns by default on create' do
           subcomment = FactoryGirl.create :subcomment, article: article
-          article.should_receive(:update_columns).with({comments_count: 1})
           subcomment.update_attributes subcomment: false
+          expect(article.reload.comments_count).to eq(1)
         end
 
-        context "when plus is a set value" do
-          it "increases the column by 1 if :plus is satisfied" do
+        context 'when plus is a set value' do
+          it 'increases the column by 1 if :plus is satisfied' do
             subcomment = FactoryGirl.create :subcomment, article: article
             article.reload
             article.comments_count.should == 0
@@ -107,8 +120,8 @@ describe PlusPlus do
           end
         end
 
-        context "when plus is a proc" do
-          it "increases the column by the proc value if :plus is satisfied" do
+        context 'when plus is a proc' do
+          it 'increases the column by the proc value if :plus is satisfied' do
             subcomment = FactoryGirl.create :subcomment, user: user
             user.reload
             user.score.should == 0
@@ -118,8 +131,9 @@ describe PlusPlus do
           end
         end
 
-        context "when minus is a set valus" do
-          it "decreases the column by 1 if :minus is satisfied" do
+        context 'when minus is a set valus' do
+          it 'decreases the column by 1 if :minus is satisfied' do
+            article_with_comment.reload
             article_with_comment.comments_count.should == 1
             article_with_comment.comments[0].update_attributes subcomment: true
             article_with_comment.reload
@@ -127,8 +141,9 @@ describe PlusPlus do
           end
         end
 
-        context "when minus is a proc" do
-          it "decreases the column by 1 if :minus is satisfied" do
+        context 'when minus is a proc' do
+          it 'decreases the column by 1 if :minus is satisfied' do
+            user_with_comment.reload
             user_with_comment.score.should == 5
             user_with_comment.comments[0].update_attributes subcomment: true
             user_with_comment.reload
@@ -139,6 +154,6 @@ describe PlusPlus do
     end
   end
 
-  it "should raise an error if the association is unknown"
-  it "should raise an error if a column is not specified"
+  it 'should raise an error if the association is unknown'
+  it 'should raise an error if a column is not specified'
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -18,8 +18,8 @@ class Comment < ActiveRecord::Base
   belongs_to :article
 
   plus_plus :user, :comments_count
-  plus_plus :user, :score, value: 5, unless: proc { subcomment }
+  plus_plus :user, :score, value: 5, update_method: :update_attributes, unless: proc { subcomment }
   plus_plus :article, :comments_count, unless: proc { subcomment }
   plus_plus_on_change :article, :comments_count, changed: :subcomment, plus: false, minus: true
-  plus_plus_on_change :user, :score, changed: :subcomment, plus: proc { !subcomment }, minus: proc { subcomment }, value: 5
+  plus_plus_on_change :user, :score, changed: :subcomment, plus: proc { !subcomment }, minus: proc { subcomment }, value: 5, update_method: :update_attributes
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -18,8 +18,8 @@ class Comment < ActiveRecord::Base
   belongs_to :article
 
   plus_plus :user, :comments_count
-  plus_plus :user, :score, value: 5, update_method: :update_attributes, unless: proc { subcomment }
+  plus_plus :user, :score, value: 5, unless: proc { subcomment }
   plus_plus :article, :comments_count, unless: proc { subcomment }
   plus_plus_on_change :article, :comments_count, changed: :subcomment, plus: false, minus: true
-  plus_plus_on_change :user, :score, changed: :subcomment, plus: proc { !subcomment }, minus: proc { subcomment }, value: 5, update_method: :update_attributes
+  plus_plus_on_change :user, :score, changed: :subcomment, plus: proc { !subcomment }, minus: proc { subcomment }, value: 5
 end


### PR DESCRIPTION
Looking at the internals [1] and [2], it's not hard to see that race conditions happen, 
since the math is done in Ruby-land and the updated value is sent to the DB.

[1] https://github.com/Pathgather/plus-plus/blob/master/lib/plus_plus/base.rb#L40
[2] https://github.com/Pathgather/plus-plus/blob/master/lib/plus_plus/base.rb#L69-L70